### PR TITLE
Implement `Automaton::eval_io`

### DIFF
--- a/src/automaton.rs
+++ b/src/automaton.rs
@@ -37,86 +37,9 @@ impl<T: Token, S> From<Dfa<S>> for Automaton<T, S> {
 impl<T: Token, S> Automaton<T, S> {
     pub fn eval<I, J>(&self, s: &mut S, input: I) -> bool
             where I: Iterator<Item=J>,
-                  J: Input<T> {
-
-        let mut state = self.enter;
-
-        debug!("EVAL; state={}", state);
-
-        for val in input {
-            debug!("  input={}", val.as_u32());
-
-            loop {
-                match self.ops[state] {
-                    Op::Lookup(ref table, _) => {
-                        match table.lookup(val.as_u32()) {
-                            Some(dest) => {
-                                debug!("  matching input; success; state={}; jump={}", state, dest);
-                                state = dest;
-                                break;
-                            }
-                            None => {
-                                debug!("  matching input; state={}; FAIL", state);
-                                return false;
-                            }
-                        }
-                    }
-                    Op::Jump(dst) => {
-                        debug!("  state={}; jump={}", state, dst);
-                        state = dst;
-                    }
-                    Op::Invoke(ref actions) => {
-                        debug!("  invoking actions; state={}", state);
-                        for &action in actions {
-                            self.actions[action](s);
-                        }
-                        state += 1;
-                    }
-                    Op::Terminal => {
-                        debug!("  unexpected terminal; state={}", state);
-                        // Not expecting a terminal
-                        return false;
-                    }
-                    _ => {
-                        panic!("oh noes, we haz a bug: unexpected op in automaton");
-                    }
-                }
-            }
-        }
-
-        // Handle exit
-        loop {
-            match self.ops[state] {
-                Op::Lookup(_, term) => {
-                    if term == INVALID {
-                        debug!("  invalid termination state; state={}", state);
-                        return false;
-                    }
-
-                    debug!("");
-
-                    state = term;
-                }
-                Op::Jump(dst) => {
-                    debug!("  state={}; jump={}", state, dst);
-                    state = dst;
-                }
-                Op::Invoke(ref actions) => {
-                    debug!("  invoking actions; state={}", state);
-                    for &action in actions {
-                        self.actions[action](s);
-                    }
-                    state += 1;
-                }
-                Op::Terminal => {
-                    debug!("  terminal -- ending; state={}", state);
-                    return true;
-                }
-                _ => {
-                    panic!("oh noes, we haz a bug: unexpected op in automaton");
-                }
-            }
-        }
+                  J: Input<T>
+    {
+        self.try_eval(s, input.map(Ok)).expect("can't be err")
     }
 
     pub fn try_eval<I, J>(&self, s: &mut S, input: I) -> Result<bool, ::std::io::CharsError>

--- a/src/automaton.rs
+++ b/src/automaton.rs
@@ -1,6 +1,6 @@
 // use {info, Dfa, Token, Input};
 use core::{Action, Dfa, Token, Transition, Letter, Input, State};
-use std::{cmp, fmt, iter, usize};
+use std::{cmp, fmt, iter, io, usize};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::marker::PhantomData;
@@ -39,11 +39,11 @@ impl<T: Token, S> Automaton<T, S> {
             where I: Iterator<Item=J>,
                   J: Input<T>
     {
-        self.try_eval(s, input.map(Ok)).expect("can't be err")
+        self.eval_io(s, input.map(Ok)).expect("can't be err")
     }
 
-    pub fn try_eval<I, J>(&self, s: &mut S, input: I) -> Result<bool, ::std::io::CharsError>
-        where I: Iterator<Item=Result<J, ::std::io::CharsError>>,
+    pub fn eval_io<I, J>(&self, s: &mut S, input: I) -> Result<bool, io::Error>
+        where I: Iterator<Item=Result<J, io::Error>>,
               J: Input<T>
     {
         let mut state = self.enter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(io)]
+
 #![allow(dead_code, unused_variables, unused_mut, unreachable_code)]
 #![deny(warnings)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(io)]
-
 #![allow(dead_code, unused_variables, unused_mut, unreachable_code)]
 #![deny(warnings)]
 

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,5 +1,3 @@
-#![feature(io)]
-
 extern crate automaton;
 
 mod test_intersection;

--- a/test/test.rs
+++ b/test/test.rs
@@ -1,7 +1,10 @@
+#![feature(io)]
+
 extern crate automaton;
 
 mod test_intersection;
 mod test_kleene;
 mod test_range;
 mod test_sequence;
+mod test_stream;
 mod test_union;

--- a/test/test_stream.rs
+++ b/test/test_stream.rs
@@ -1,0 +1,15 @@
+use std::io::Read;
+use automaton::*;
+use automaton::encoding::Ascii;
+
+#[test]
+pub fn test_stream() {
+    let machine: Automaton<Ascii, ()> =
+        Ascii::exact("a")
+            .kleene()
+            .concat(Ascii::exact("b"))
+            .compile();
+
+    let stream = "aaaaaab".as_bytes();
+    assert!(machine.try_eval(&mut (), stream.chars()).is_ok());
+}

--- a/test/test_stream.rs
+++ b/test/test_stream.rs
@@ -11,5 +11,5 @@ pub fn test_stream() {
             .compile();
 
     let stream = "aaaaaab".as_bytes();
-    assert!(machine.try_eval(&mut (), stream.chars()).is_ok());
+    assert!(machine.eval_io(&mut (), stream.bytes()).is_ok());
 }


### PR DESCRIPTION
This allows working with streams of data without having to map unwrap before passing off to `eval`, presumably, this will play nicely with a larger effort to handle errors.
